### PR TITLE
import wadfile/mapfile separation from upstream Weland

### DIFF
--- a/Assets/Scripts/Weland/ISerializableBE.cs
+++ b/Assets/Scripts/Weland/ISerializableBE.cs
@@ -1,0 +1,6 @@
+namespace Weland {
+    interface ISerializableBE {
+	void Load(BinaryReaderBE reader);
+	void Save(BinaryWriterBE writer);
+    }
+}

--- a/Assets/Scripts/Weland/level/Level.cs
+++ b/Assets/Scripts/Weland/level/Level.cs
@@ -3,11 +3,6 @@ using System.IO;
 using System.Collections.Generic;
 
 namespace Weland {
-    interface ISerializableBE {
-	void Load(BinaryReaderBE reader);
-	void Save(BinaryWriterBE writer);
-    }
-
     public static class World {
 	public const short One = 1024;
 	public static short FromDouble(double d) {

--- a/Assets/Scripts/Weland/level/Level.cs
+++ b/Assets/Scripts/Weland/level/Level.cs
@@ -3,31 +3,6 @@ using System.IO;
 using System.Collections.Generic;
 
 namespace Weland {
-    public static class World {
-	public const short One = 1024;
-	public static short FromDouble(double d) {
-	    return (short) Math.Round(d * World.One);
-	}
-
-	public static double ToDouble(short w) {
-	    return ((double) w / World.One);
-	}
-
-	public static double ToDouble(int i) {
-	    return ((double) i / World.One);
-	}
-    }
-
-    public static class Angle {
-	const short AngularPrecision = 512;
-	public static short FromDouble(double d) {
-	    return (short) Math.Round(d * AngularPrecision / 360);
-	}
-	public static double ToDouble(short a) {
-	    return ((double) a * 360 / AngularPrecision);
-	}
-    }
-
     public partial class Level {
 	public List<Point> Endpoints = new List<Point> ();
 	public List<Line> Lines = new List<Line>();
@@ -76,7 +51,7 @@ namespace Weland {
 	    Wadfile.Chunk("MNpx"),
 	    Wadfile.Chunk("FXpx"),
 	    Wadfile.Chunk("PRpx"),
-	    Wadfile.Chunk("RXpx"),
+	    Wadfile.Chunk("PXpx"),
 	    Wadfile.Chunk("WPpx"),
 	};
 

--- a/Assets/Scripts/Weland/level/MapFile.cs
+++ b/Assets/Scripts/Weland/level/MapFile.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Weland {
+    public class MapFile : Wadfile {
+        public class Overlay {
+            public MissionFlags MissionFlags;
+	    public EnvironmentFlags EnvironmentFlags;
+	    public EntryPointFlags EntryPointFlags;
+	    public string LevelName;
+
+            internal const short DataSize = 74;
+
+            internal void LoadData(BinaryReaderBE reader) {
+		MissionFlags = (MissionFlags) reader.ReadInt16();
+		EnvironmentFlags = (EnvironmentFlags) reader.ReadInt16();
+		EntryPointFlags = (EntryPointFlags) reader.ReadInt32();
+		LevelName = reader.ReadMacString(MapInfo.LevelNameLength);
+	    }
+
+            internal void SaveData(BinaryWriterBE writer) {
+		writer.Write((short) MissionFlags);
+		writer.Write((short) EnvironmentFlags);
+		writer.Write((int) EntryPointFlags);
+		writer.WriteMacString(LevelName, MapInfo.LevelNameLength);
+	    }
+        }
+
+        public SortedDictionary<int, Overlay> Overlays = new SortedDictionary<int, Overlay>();
+
+        protected override void SetApplicationSpecificDirectoryDataSize() {
+            if (Directory.Count == 1) {
+                applicationSpecificDirectoryDataSize = 0;
+            } else {
+                applicationSpecificDirectoryDataSize = Overlay.DataSize;
+            }
+        }
+
+        protected override void LoadApplicationSpecificDirectoryData(BinaryReaderBE reader, int index)
+        {
+            if (applicationSpecificDirectoryDataSize == Overlay.DataSize) {
+                Overlay overlay = new Overlay();
+                overlay.LoadData(reader);
+                Overlays[index] = overlay;
+            }
+        }
+
+        protected override void SaveApplicationSpecificDirectoryData(BinaryWriterBE writer, int index)
+        {
+            if (applicationSpecificDirectoryDataSize == Overlay.DataSize) {
+                Overlays[index].SaveData(writer);
+            }
+        }
+
+        protected override uint[] GetTagOrder() {
+            return new uint[] { Point.Tag, Line.Tag, Side.Tag, Polygon.Tag, Light.Tag, Annotation.Tag, MapObject.Tag, MapInfo.Tag, Placement.Tag, Platform.StaticTag, Media.Tag, AmbientSound.Tag, RandomSound.Tag };
+        }
+
+        public override void Load(string filename) {
+            base.Load(filename);
+
+            if (DataVersion < 1) {
+                throw new BadMapException("Only Marathon 2 and higher maps are supported");
+            }
+
+            if (applicationSpecificDirectoryDataSize != Overlay.DataSize) {
+                foreach(var kvp in Directory) {
+                    if (kvp.Value.Chunks.ContainsKey(MapInfo.Tag)) {
+                        MapInfo info = new MapInfo();
+                        BinaryReaderBE chunkReader = new BinaryReaderBE(new MemoryStream(kvp.Value.Chunks[MapInfo.Tag]));
+                        info.Load(chunkReader);
+
+                        Overlay overlay = new Overlay();
+                        overlay.MissionFlags = info.MissionFlags;
+                        overlay.EnvironmentFlags = info.EnvironmentFlags;
+                        overlay.EntryPointFlags = info.EntryPointFlags;
+                        overlay.LevelName = info.Name;
+
+                        Overlays[kvp.Value.Index] = overlay;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Weland/level/World.cs
+++ b/Assets/Scripts/Weland/level/World.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Weland {
+     public static class World {
+	public const short One = 1024;
+	public static short FromDouble(double d) {
+	    return (short) Math.Round(d * World.One);
+	}
+
+	public static double ToDouble(short w) {
+	    return ((double) w / World.One);
+	}
+
+	public static double ToDouble(int i) {
+	    return ((double) i / World.One);
+	}
+    }
+
+    public static class Angle {
+	const short AngularPrecision = 512;
+	public static short FromDouble(double d) {
+	    return (short) Math.Round(d * AngularPrecision / 360);
+	}
+	public static double ToDouble(short a) {
+	    return ((double) a * 360 / AngularPrecision);
+	}
+    }
+}

--- a/Assets/Scripts/Weland/physics/AttackDefinition.cs
+++ b/Assets/Scripts/Weland/physics/AttackDefinition.cs
@@ -1,0 +1,25 @@
+namespace Weland {
+    public struct AttackDefinition {
+        public short Type;
+        public short Repetitions;
+        public double Angle;
+        public short Range;
+        public short AttackShape;
+
+        public short Dx;
+        public short Dy;
+        public short Dz;
+
+        public void Load(BinaryReaderBE reader) {
+            Type = reader.ReadInt16();
+            Repetitions = reader.ReadInt16();
+            Angle = Weland.Angle.ToDouble(reader.ReadInt16());
+            Range = reader.ReadInt16();
+            AttackShape = reader.ReadInt16();
+
+            Dx = reader.ReadInt16();
+            Dy = reader.ReadInt16();
+            Dz = reader.ReadInt16();
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/DamageDefinition.cs
+++ b/Assets/Scripts/Weland/physics/DamageDefinition.cs
@@ -1,0 +1,17 @@
+namespace Weland {
+    public struct DamageDefinition {
+        public short Type;
+        public short Flags;
+        public short Base;
+        public short Random;
+        public double Scale;
+        
+        public void Load(BinaryReaderBE reader) {
+            Type = reader.ReadInt16();
+            Flags = reader.ReadInt16();
+            Base = reader.ReadInt16();
+            Random = reader.ReadInt16();
+            Scale = reader.ReadFixed();
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/EffectDefinition.cs
+++ b/Assets/Scripts/Weland/physics/EffectDefinition.cs
@@ -1,0 +1,28 @@
+namespace Weland {
+    public class EffectDefinition : ISerializableBE {
+        public static readonly uint Tag = Wadfile.Chunk("FXpx");
+
+        public short Collection;
+        public short Shape;
+        public double SoundPitch;
+        public ushort Flags;
+        public short Delay;
+        public short DelaySound;
+
+        public void Load(BinaryReaderBE reader) {
+            Collection = reader.ReadInt16();
+            Shape = reader.ReadInt16();
+            
+            SoundPitch = reader.ReadFixed();
+
+            Flags = reader.ReadUInt16();
+
+            Delay = reader.ReadInt16();
+            DelaySound = reader.ReadInt16();
+        }
+
+        public void Save(BinaryWriterBE writer) {
+            
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/MonsterDefinition.cs
+++ b/Assets/Scripts/Weland/physics/MonsterDefinition.cs
@@ -1,0 +1,138 @@
+namespace Weland {
+    public class MonsterDefinition : ISerializableBE {
+        public static readonly uint Tag = Wadfile.Chunk("MNpx");
+
+        public short Collection;
+        public short Vitality;
+        
+        public uint Immunities;
+        public uint Weaknesses;
+        public uint Flags;
+
+        public int Class;
+        public int Friends;
+        public int Enemies;
+
+        public double SoundPitch;
+
+        public short ActivationSound;
+        public short FriendlyActivationSound;
+        public short ClearSound;
+        public short KillSound;
+        public short ApologySound;
+        public short FriendlyFireSound;
+        public short FlamingSound;
+        public short RandomSound;
+        public short RandomSoundMask;
+
+        public short CarryingItemType;
+
+        public short Radius;
+        public short Height;
+        public short PreferredHoverHeight;
+        public short MinimumLedgeDelta;
+        public short MaximumLedgeDelta;
+
+        public double ExternalVelocityScale;
+
+        public short ImpactEffect;
+        public short MeleeImpactEffect;
+        public short ContrailEffect;
+
+        public short HalfVisualArc;
+        public short HalfVerticalVisualArc;
+        public short VisualRange;
+        public short DarkVisualRange;
+
+        public short Intelligence;
+        public short Speed;
+        public short Gravity;
+        public short TerminalVelocity;
+        public short DoorRetryMask;
+        public short ShrapnelRadius;
+
+        public DamageDefinition ShrapnelDamage;
+
+        public short HitShapes;
+        public short HardDyingShape;
+        public short SoftDyingShape;
+        public short HardDeadShapes;
+        public short SoftDeadShapes;
+        public short StationaryShape;
+        public short MovingShape;
+        public short TeleportInShape;
+        public short TeleportOutShape;
+
+        public short AttackFrequency;
+
+        public AttackDefinition MeleeAttack;
+        public AttackDefinition RangedAttack;
+
+        public void Load(BinaryReaderBE reader) {
+            Collection = reader.ReadInt16();
+            
+            Vitality = reader.ReadInt16();
+            Immunities = reader.ReadUInt32();
+            Weaknesses = reader.ReadUInt32();
+            Flags = reader.ReadUInt32();
+
+            Class = reader.ReadInt32();
+            Friends = reader.ReadInt32();
+            Enemies = reader.ReadInt32();
+
+            SoundPitch = reader.ReadFixed();
+
+            ActivationSound = reader.ReadInt16();
+            FriendlyActivationSound = reader.ReadInt16();
+            ClearSound = reader.ReadInt16();
+            KillSound = reader.ReadInt16();
+            ApologySound = reader.ReadInt16();
+            FriendlyFireSound = reader.ReadInt16();
+            FlamingSound = reader.ReadInt16();
+            RandomSound = reader.ReadInt16();
+            RandomSoundMask = reader.ReadInt16();
+
+            CarryingItemType = reader.ReadInt16();
+
+            Radius = reader.ReadInt16();
+            Height = reader.ReadInt16();
+            PreferredHoverHeight = reader.ReadInt16();
+            MinimumLedgeDelta = reader.ReadInt16();
+            MaximumLedgeDelta = reader.ReadInt16();
+            ExternalVelocityScale = reader.ReadFixed();
+            ImpactEffect = reader.ReadInt16();
+            MeleeImpactEffect = reader.ReadInt16();
+            ContrailEffect = reader.ReadInt16();
+
+            HalfVisualArc = reader.ReadInt16();
+            HalfVerticalVisualArc = reader.ReadInt16();
+            VisualRange = reader.ReadInt16();
+            DarkVisualRange = reader.ReadInt16();
+            Intelligence = reader.ReadInt16();
+            Speed = reader.ReadInt16();
+            Gravity = reader.ReadInt16();
+            TerminalVelocity = reader.ReadInt16();
+            DoorRetryMask = reader.ReadInt16();
+            ShrapnelRadius = reader.ReadInt16();
+            ShrapnelDamage.Load(reader);
+
+            HitShapes = reader.ReadInt16();
+            HardDyingShape = reader.ReadInt16();
+            SoftDyingShape = reader.ReadInt16();
+            HardDeadShapes = reader.ReadInt16();
+            SoftDeadShapes = reader.ReadInt16();
+            StationaryShape = reader.ReadInt16();
+            MovingShape = reader.ReadInt16();
+            TeleportInShape = reader.ReadInt16();
+            TeleportOutShape = reader.ReadInt16();
+
+            AttackFrequency = reader.ReadInt16();
+            MeleeAttack.Load(reader);
+            RangedAttack.Load(reader);
+        }
+
+        public void Save(BinaryWriterBE writer) {
+
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/PhysicsConstants.cs
+++ b/Assets/Scripts/Weland/physics/PhysicsConstants.cs
@@ -1,0 +1,83 @@
+namespace Weland {
+    public class PhysicsConstants : ISerializableBE {
+        public static readonly uint Tag = Wadfile.Chunk("PXpx");
+
+        public double MaximumForwardVelocity;
+        public double MaximumBackwardVelocity;
+        public double MaximumPerpendicularVelocity;
+
+        public double Acceleration;
+        public double Deceleration;
+        public double AirborneDeceleration;
+
+        public double GravitationalAcceleration;
+        public double ClimbingAcceleration;
+        public double TerminalVelocity;
+
+        public double ExternalAcceleration;
+
+        public double AngularAcceleration;
+        public double AngularDeceleration;
+        public double MaximumAngularVelocity;
+        public double AngularRecenteringVelocity;
+
+        public double FastAngularVelocity;
+        public double FastAngularMaximum;
+
+        public double MaximumElevation;
+        public double ExternalAngularDeceleration;
+
+        public double StepDelta;
+        public double StepAmplitude;
+
+        public double Radius;
+        public double Height;
+        public double DeadHeight;
+        public double CameraHeight;
+        public double SplashHeight;
+
+        public double HalfCameraSeparation;
+
+        public void Load(BinaryReaderBE reader) {
+            MaximumForwardVelocity = reader.ReadFixed();
+            MaximumBackwardVelocity = reader.ReadFixed();
+            MaximumPerpendicularVelocity = reader.ReadFixed();
+
+            Acceleration = reader.ReadFixed();
+            Deceleration = reader.ReadFixed();
+            AirborneDeceleration = reader.ReadFixed();
+
+            GravitationalAcceleration = reader.ReadFixed();
+            ClimbingAcceleration = reader.ReadFixed();
+            TerminalVelocity = reader.ReadFixed();
+
+            ExternalAcceleration = reader.ReadFixed();
+
+            AngularAcceleration = reader.ReadFixed();
+            AngularDeceleration = reader.ReadFixed();
+            MaximumAngularVelocity = reader.ReadFixed();
+            AngularRecenteringVelocity = reader.ReadFixed();
+
+            FastAngularVelocity = reader.ReadFixed();
+            FastAngularMaximum = reader.ReadFixed();
+
+            MaximumElevation = reader.ReadFixed();
+            ExternalAngularDeceleration = reader.ReadFixed();
+
+            StepDelta = reader.ReadFixed();
+            StepAmplitude = reader.ReadFixed();
+
+            Radius = reader.ReadFixed();
+            Height = reader.ReadFixed();
+            DeadHeight = reader.ReadFixed();
+            CameraHeight = reader.ReadFixed();
+            SplashHeight = reader.ReadFixed();
+
+            HalfCameraSeparation = reader.ReadFixed();
+        }
+
+        public void Save(BinaryWriterBE writer) {
+
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/PhysicsModel.cs
+++ b/Assets/Scripts/Weland/physics/PhysicsModel.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Weland {
+    public class PhysicsModel {
+        public class BadPhysicsException : Exception {
+            public BadPhysicsException() { }
+            public BadPhysicsException(string message) : base(message) { }
+            public BadPhysicsException(string message, Exception inner) :
+                base(message, inner) { }
+        }
+            
+        public List<MonsterDefinition> MonsterDefinitions {
+            get { return monsterDefinitions; }
+        }
+
+        public List<EffectDefinition> EffectDefinitions {
+            get { return effectDefinitions; }
+        }
+
+        public List<ProjectileDefinition> ProjectileDefinitions {
+            get { return projectileDefinitions; }
+        }
+
+        public List<PhysicsConstants> PhysicsConstants {
+            get { return physicsConstants; }
+        }
+
+        public List<WeaponDefinition> WeaponDefinitions {
+            get { return weaponDefinitions; }
+        }
+
+        public void Load(string filename) {
+            Wadfile file = new Wadfile();
+            file.Load(filename);
+            if (file.Directory.Count == 1) {
+                Load(file.Directory[0]);
+            } else {
+                throw new BadPhysicsException("Invalid physics file");
+            }
+        }
+
+        public void Load(Wadfile.DirectoryEntry wad) {
+            if (wad.Chunks.ContainsKey(MonsterDefinition.Tag)) {
+                LoadChunkList<MonsterDefinition>(monsterDefinitions, wad.Chunks[MonsterDefinition.Tag]);
+            } else {
+                throw new BadPhysicsException("Invalid physics: missing monster definitions");
+            }
+
+            if (wad.Chunks.ContainsKey(EffectDefinition.Tag)) {
+                LoadChunkList<EffectDefinition>(effectDefinitions, wad.Chunks[EffectDefinition.Tag]);
+            } else {
+                throw new BadPhysicsException("Invalid physics: missing effects definitions");
+            }
+
+            if (wad.Chunks.ContainsKey(ProjectileDefinition.Tag)) {
+                LoadChunkList<ProjectileDefinition>(projectileDefinitions, wad.Chunks[ProjectileDefinition.Tag]);
+            } else {
+                throw new BadPhysicsException("Invalid physics: missing projectile definitions");
+            }
+
+            if (wad.Chunks.ContainsKey(Weland.PhysicsConstants.Tag)) {
+                LoadChunkList<PhysicsConstants>(physicsConstants, wad.Chunks[Weland.PhysicsConstants.Tag]);
+            } else {
+                throw new BadPhysicsException("Invalid physics: missing physics constants");
+            }
+
+             if (wad.Chunks.ContainsKey(WeaponDefinition.Tag)) {
+                LoadChunkList<WeaponDefinition>(weaponDefinitions, wad.Chunks[WeaponDefinition.Tag]);
+            } else {
+                throw new BadPhysicsException("Invalid physics: missing weapon definitions");
+            }
+        }
+        
+        public static void Main(string[] args) {
+            if (args.Length == 1) {
+                PhysicsModel model = new PhysicsModel();
+                model.Load(args[0]);
+
+                Console.WriteLine("{0} monster definitions", model.monsterDefinitions.Count);
+                Console.WriteLine(new System.Web.Script.Serialization.JavaScriptSerializer().Serialize(model));
+            } else {
+                Console.WriteLine("Usage: PhysicsModel <filename>");
+            }
+        }
+
+        void LoadChunkList<T>(List<T> list, byte[] data) where T : ISerializableBE, new() {
+	    BinaryReaderBE reader = new BinaryReaderBE(new MemoryStream(data));
+	    list.Clear();
+	    while (reader.BaseStream.Position < reader.BaseStream.Length) {
+		T t = new T();
+		t.Load(reader);
+		list.Add(t);
+	    }
+	}
+
+        List<MonsterDefinition> monsterDefinitions = new List<MonsterDefinition>();
+        List<EffectDefinition> effectDefinitions = new List<EffectDefinition>();
+        List<ProjectileDefinition> projectileDefinitions = new List<ProjectileDefinition>();
+        List<PhysicsConstants> physicsConstants = new List<PhysicsConstants>();
+        List<WeaponDefinition> weaponDefinitions = new List<WeaponDefinition>();
+    }
+}

--- a/Assets/Scripts/Weland/physics/ProjectileDefinition.cs
+++ b/Assets/Scripts/Weland/physics/ProjectileDefinition.cs
@@ -1,0 +1,61 @@
+namespace Weland {
+    public class ProjectileDefinition : ISerializableBE {
+        public static readonly uint Tag = Wadfile.Chunk("PRpx");
+
+        public short Collection;
+        public short Shape;
+        
+        public short DetonationEffect;
+        public short MediaDetonationEffect;
+        
+        public short ContrailEffect;
+        public short TicksBetweenContrails;
+        public short MaximumContrails;
+
+        public short MediaProjectilePromotion;
+
+        public short Radius;
+        public short AreaOfEffect;
+        public DamageDefinition Damage;
+
+        public uint Flags;
+
+        public short Speed;
+        public short MaximumRange;
+
+        public double SoundPitch;
+        public short FlybySound;
+        public short ReboundSound;
+
+        public void Load(BinaryReaderBE reader) {
+            Collection = reader.ReadInt16();
+            Shape = reader.ReadInt16();
+
+            DetonationEffect = reader.ReadInt16();
+            MediaDetonationEffect = reader.ReadInt16();
+
+            ContrailEffect = reader.ReadInt16();
+            TicksBetweenContrails = reader.ReadInt16();
+            MaximumContrails = reader.ReadInt16();
+
+            MediaProjectilePromotion = reader.ReadInt16();
+
+            Radius = reader.ReadInt16();
+            AreaOfEffect = reader.ReadInt16();
+            Damage.Load(reader);
+
+            Flags = reader.ReadUInt32();
+
+            Speed = reader.ReadInt16();
+            MaximumRange = reader.ReadInt16();
+
+            SoundPitch = reader.ReadFixed();
+            FlybySound = reader.ReadInt16();
+            ReboundSound = reader.ReadInt16();
+        }
+
+        public void Save(BinaryWriterBE writer) {
+
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/TriggerDefinition.cs
+++ b/Assets/Scripts/Weland/physics/TriggerDefinition.cs
@@ -1,0 +1,43 @@
+namespace Weland {
+    public class TriggerDefinition {
+        public short RoundsPerMagazine;
+        public short AmmunitionType;
+        public short TicksPerRound;
+        public short RecoveryTicks;
+        public short ChargingTicks;
+        public short RecoilMagnitude;
+        public short FiringSound;
+        public short ClickSound;
+        public short ChargingSound;
+        public short ShellCasingSound;
+        public short ReloadingSound;
+        public short ChargedSound;
+        public short ProjectileType;
+        public short ThetaError;
+        public short Dx;
+        public short Dz;
+        public short ShellCasingType;
+        public short BurstCount;
+
+        public void Load(BinaryReaderBE reader) {
+            RoundsPerMagazine = reader.ReadInt16();
+            AmmunitionType = reader.ReadInt16();
+            TicksPerRound = reader.ReadInt16();
+            RecoveryTicks = reader.ReadInt16();
+            ChargingTicks = reader.ReadInt16();
+            RecoilMagnitude = reader.ReadInt16();
+            FiringSound = reader.ReadInt16();
+            ClickSound = reader.ReadInt16();
+            ChargingSound = reader.ReadInt16();
+            ShellCasingSound = reader.ReadInt16();
+            ReloadingSound = reader.ReadInt16();
+            ChargedSound = reader.ReadInt16();
+            ProjectileType = reader.ReadInt16();
+            ThetaError = reader.ReadInt16();
+            Dx = reader.ReadInt16();
+            Dz = reader.ReadInt16();
+            ShellCasingType = reader.ReadInt16();
+            BurstCount = reader.ReadInt16();
+        }
+    }
+}

--- a/Assets/Scripts/Weland/physics/WeaponDefinition.cs
+++ b/Assets/Scripts/Weland/physics/WeaponDefinition.cs
@@ -1,0 +1,76 @@
+namespace Weland {
+    public class WeaponDefinition : ISerializableBE {
+        public static readonly uint Tag = Wadfile.Chunk("WPpx");
+
+        public short ItemType;
+        public short PowerupType;
+        public short WeaponClass;
+        public short Flags;
+        
+        public double FiringLightIntensity;
+        public short FiringIntensityDecayTicks;
+        
+        public double IdleHeight;
+        public double BobAmplitude;
+        public double KickHeight;
+        public double ReloadHeight;
+        public double IdleWidth;
+        public double HorizontalAmplitude;
+        
+        public short Collection;
+        public short IdleShape;
+        public short FiringShape;
+        public short ReloadingShape;
+        public short Unused;
+        public short ChargingShape;
+        public short ChargedShape;
+        
+        public short ReadyTicks;
+        public short AwaitReloadTicks;
+        public short LoadingTicks;
+        public short FinishLoadingTicks;
+        public short PowerupTicks;
+
+        public TriggerDefinition[] Triggers = new TriggerDefinition[2];
+        
+        public void Load(BinaryReaderBE reader) {
+            ItemType = reader.ReadInt16();
+            PowerupType = reader.ReadInt16();
+            WeaponClass = reader.ReadInt16();
+            Flags = reader.ReadInt16();
+
+            FiringLightIntensity = reader.ReadFixed();
+            FiringIntensityDecayTicks = reader.ReadInt16();
+
+            IdleHeight = reader.ReadFixed();
+            BobAmplitude = reader.ReadFixed();
+            KickHeight = reader.ReadFixed();
+            ReloadHeight = reader.ReadFixed();
+            IdleWidth = reader.ReadFixed();
+            HorizontalAmplitude = reader.ReadFixed();
+
+            Collection = reader.ReadInt16();
+            IdleShape = reader.ReadInt16();
+            FiringShape = reader.ReadInt16();
+            ReloadingShape = reader.ReadInt16();
+            Unused = reader.ReadInt16();
+            ChargingShape = reader.ReadInt16();
+            ChargedShape = reader.ReadInt16();
+
+            ReadyTicks = reader.ReadInt16();
+            AwaitReloadTicks = reader.ReadInt16();
+            LoadingTicks = reader.ReadInt16();
+            FinishLoadingTicks = reader.ReadInt16();
+            PowerupTicks = reader.ReadInt16();
+
+            for (int i = 0; i < 2; ++i) {
+                Triggers[i] = new TriggerDefinition();
+                Triggers[i].Load(reader);
+            }
+        }
+
+        public void Save(BinaryWriterBE writer) {
+
+        }
+    }
+}


### PR DESCRIPTION
This separation is necessary [?useful] to get physics loading working. Issuing an early pull request because it will require some integration changes: any place you use Wadfile now, you should just be able to switch to MapFile instead. I don't think you use any of the "application specific data" but if you do that has been moved into MapFile.Overlays

Let me know if you have any questions.